### PR TITLE
[Feat] Add NestJS mock API suite

### DIFF
--- a/src/api-client/send/send.module.ts
+++ b/src/api-client/send/send.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { SendController } from "./send.controller";
+import { SendService } from "./send.service";
+
+@Module({
+  controllers: [SendController],
+  providers: [SendService],
+})
+export class SendModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,32 @@
-import { Module } from '@nestjs/common';
-import { AlertsModule } from './alerts/alerts.module';
+import { Module } from "@nestjs/common";
+import { AlertsModule } from "./alerts/alerts.module";
+import { DashboardModule } from "./dashboard/dashboard.module";
+import { DiffModule } from "./diff/diff.module";
+import { ClusterModule } from "./cluster/cluster.module";
+import { BrokerModule } from "./broker/broker.module";
+import { RequestModule } from "./api-client/requests/request.module";
+import { SendModule } from "./api-client/send/send.module";
+import { GalleryModule } from "./gallery/gallery.module";
+import { HealthModule } from "./health/health.module";
+import { LogsModule } from "./logs/logs.module";
+import { MetricsModule } from "./metrics/metrics.module";
+import { TopicsModule } from "./topics/topics.module";
 
+// Nest는 트리 구조이기 때문에 루트에서 연결 되어야한다!
 @Module({
-  imports: [AlertsModule],
+  imports: [
+    AlertsModule,
+    BrokerModule,
+    RequestModule,
+    SendModule,
+    ClusterModule,
+    DashboardModule,
+    DiffModule,
+    GalleryModule,
+    HealthModule,
+    LogsModule,
+    MetricsModule,
+    TopicsModule,
+  ],
 })
 export class AppModule {}

--- a/src/dashboard/dashboard.controller.ts
+++ b/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Controller,
+  Get,
+  Options,
+  Res,
+  UseFilters,
+  UseInterceptors,
+  HttpCode,
+} from "@nestjs/common";
+import type { Response } from "express";
+
+import { DashboardService } from "./dashboard.service";
+import { corsHeaders } from "./dashboard.cors";
+import {
+  ApiResponseInterceptor,
+  ApiExceptionFilter,
+} from "src/common/http/api-response";
+import { DashboardDataDto } from "./dto/dashboard.dto";
+
+@Controller("api/dashboard")
+@UseInterceptors(ApiResponseInterceptor)
+@UseFilters(ApiExceptionFilter)
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Options()
+  @HttpCode(204)
+  options(@Res() res: Response) {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+    return res.send();
+  }
+
+  @Get()
+  getDashboard(@Res({ passthrough: true }) res: Response): DashboardDataDto {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+    return this.dashboardService.getDashboard();
+  }
+}

--- a/src/dashboard/dashboard.cors.ts
+++ b/src/dashboard/dashboard.cors.ts
@@ -1,0 +1,6 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;

--- a/src/dashboard/dashboard.mock.ts
+++ b/src/dashboard/dashboard.mock.ts
@@ -1,0 +1,58 @@
+import { DashboardDataDto } from "./dto/dashboard.dto";
+
+export const DASHBOARD_MOCK: DashboardDataDto = {
+  summary: {
+    activeBranch: "main",
+    lastDeploy: "2025-11-14 10:32",
+    openIssues: { total: 12, critical: 3, major: 4, minor: 5 },
+    build: { status: "Passing", lastRunLabel: "#184 · 2 min ago" },
+  },
+  tasks: {
+    completed: 3,
+    total: 6,
+    items: [
+      {
+        id: "t1",
+        done: false,
+        title: "Refactor chart widget for pie chart support",
+        meta: "/src/components/chart/CustomChart.tsx",
+        accent: "point",
+      },
+      {
+        id: "t2",
+        done: true,
+        title: "Implement VSCode-like layout for main app",
+        meta: "merged into main",
+      },
+      {
+        id: "t3",
+        done: false,
+        title: "Fix sidebar collapse animation jitter on mobile",
+        meta: "high priority · layout/VSCodeLeftMenu.tsx",
+        accent: "danger",
+      },
+    ],
+  },
+  activity: [
+    {
+      hash: "a1b2c3d",
+      message: "feat: add VSCode layout wrapper",
+      time: "10:12",
+    },
+    {
+      hash: "e4f5g6h",
+      message: "refactor: extract left menu component",
+      time: "09:43",
+    },
+    {
+      hash: "i7j8k9l",
+      message: "chore: update chart tooltip format",
+      time: "09:01",
+    },
+  ],
+  environment: {
+    runtime: ["Node 20.x", "Next.js App Router"],
+    ui: ["VSCode-like layout", "Tailwind + lucide-react"],
+    charts: ["react-chartjs-2", "CustomChart wrapper ready"],
+  },
+};

--- a/src/dashboard/dashboard.module.ts
+++ b/src/dashboard/dashboard.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { DashboardController } from "./dashboard.controller";
+import { DashboardService } from "./dashboard.service";
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/dashboard/dashboard.service.ts
+++ b/src/dashboard/dashboard.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@nestjs/common";
+import { DASHBOARD_MOCK } from "./dashboard.mock";
+import { DashboardDataDto } from "./dto/dashboard.dto";
+
+@Injectable()
+export class DashboardService {
+  getDashboard(): DashboardDataDto {
+    return structuredClone(DASHBOARD_MOCK);
+  }
+}

--- a/src/dashboard/dto/dashboard.dto.ts
+++ b/src/dashboard/dto/dashboard.dto.ts
@@ -1,0 +1,51 @@
+export class OpenIssuesDto {
+  total!: number;
+  critical!: number;
+  major!: number;
+  minor!: number;
+}
+
+export class BuildDto {
+  status!: string; // e.g. "Passing"
+  lastRunLabel!: string; // e.g. "#184 · 2 min ago"
+}
+
+export class SummaryDto {
+  activeBranch!: string;
+  lastDeploy!: string; // display string
+  openIssues!: OpenIssuesDto;
+  build!: BuildDto;
+}
+
+export class TaskItemDto {
+  id!: string;
+  done!: boolean;
+  title!: string;
+  meta!: string;
+  accent?: string; // e.g. "point" | "danger"
+}
+
+export class TasksDto {
+  completed!: number;
+  total!: number;
+  items!: TaskItemDto[];
+}
+
+export class CommitItemDto {
+  hash!: string;
+  message!: string;
+  time!: string; // display string
+}
+
+export class EnvironmentDto {
+  runtime!: string[];
+  ui!: string[];
+  charts!: string[];
+}
+
+export class DashboardDataDto {
+  summary!: SummaryDto;
+  tasks!: TasksDto;
+  activity!: CommitItemDto[];
+  environment!: EnvironmentDto;
+}

--- a/src/diff/diff.controller.ts
+++ b/src/diff/diff.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  InternalServerErrorException,
+  Options,
+  Post,
+  Res,
+} from "@nestjs/common";
+import type { Response } from "express";
+import { DiffService } from "./diff.service";
+import { DiffPayloadDto } from "./dto/diff.dto";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "http://localhost:3000",
+  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+@Controller("diff")
+export class DiffController {
+  constructor(private readonly diffService: DiffService) {}
+
+  @Options()
+  @HttpCode(204)
+  options(@Res() res: Response) {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+    return res.send();
+  }
+
+  @Get()
+  get(@Res({ passthrough: true }) res: Response): DiffPayloadDto {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+      return this.diffService.get();
+    } catch {
+      throw new InternalServerErrorException("Failed to fetch diff data");
+    }
+  }
+
+  @Post()
+  post(
+    @Body() body: unknown,
+    @Res({ passthrough: true }) res: Response
+  ): DiffPayloadDto {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      // Body can be anything; spec says ignore non-strings.
+      const partial =
+        body && typeof body === "object"
+          ? (body as {
+              original?: unknown;
+              modified?: unknown;
+              language?: unknown;
+            })
+          : {};
+
+      return this.diffService.update(partial);
+    } catch {
+      throw new InternalServerErrorException("Failed to update diff data");
+    }
+  }
+
+  @Delete()
+  reset(@Res({ passthrough: true }) res: Response): DiffPayloadDto {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+      return this.diffService.reset();
+    } catch {
+      throw new InternalServerErrorException("Failed to reset diff data");
+    }
+  }
+}

--- a/src/diff/diff.module.ts
+++ b/src/diff/diff.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { DiffController } from "./diff.controller";
+import { DiffService } from "./diff.service";
+
+@Module({
+  controllers: [DiffController],
+  providers: [DiffService],
+})
+export class DiffModule {}

--- a/src/diff/diff.seed.ts
+++ b/src/diff/diff.seed.ts
@@ -1,0 +1,9 @@
+import { DiffPayloadDto } from "./dto/diff.dto";
+
+export const DIFF_SEED_BASE = {
+  original:
+    'import React from "react";\n\nexport function Hello() {\n  return <div>Hello world!</div>;\n}\n',
+  modified:
+    'import React from "react";\n\nexport function Hello({ name }) {\n  return <div>Hello {name}</div>;\n}\n',
+  language: "typescript",
+} as const satisfies Omit<DiffPayloadDto, "updatedAt">;

--- a/src/diff/diff.service.ts
+++ b/src/diff/diff.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@nestjs/common";
+import { getDiffStore, resetDiffStore } from "./diff.store";
+import { DiffPayloadDto } from "./dto/diff.dto";
+
+type PartialDiffUpdate = {
+  original?: unknown;
+  modified?: unknown;
+  language?: unknown;
+};
+
+@Injectable()
+export class DiffService {
+  get(): DiffPayloadDto {
+    const store = getDiffStore();
+    return structuredClone(store.value);
+  }
+
+  update(partial: PartialDiffUpdate): DiffPayloadDto {
+    const store = getDiffStore();
+    const cur = store.value;
+
+    const next: DiffPayloadDto = {
+      original:
+        typeof partial.original === "string" ? partial.original : cur.original,
+      modified:
+        typeof partial.modified === "string" ? partial.modified : cur.modified,
+      language:
+        typeof partial.language === "string" ? partial.language : cur.language,
+      updatedAt: new Date().toISOString(),
+    };
+
+    store.value = next;
+    return structuredClone(store.value);
+  }
+
+  reset(): DiffPayloadDto {
+    return structuredClone(resetDiffStore());
+  }
+}

--- a/src/diff/diff.store.ts
+++ b/src/diff/diff.store.ts
@@ -1,0 +1,25 @@
+import { getGlobalSingleton } from "src/common/global-singleton";
+import { DIFF_SEED_BASE } from "./diff.seed";
+import { DiffPayloadDto } from "./dto/diff.dto";
+
+type DiffStore = { value: DiffPayloadDto };
+
+function createSeed(): DiffPayloadDto {
+  return {
+    ...DIFF_SEED_BASE,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function getDiffStore(): DiffStore {
+  // Keeps data across HMR/dev reloads via globalThis.__mockDiff
+  return getGlobalSingleton<DiffStore>("__mockDiff", () => ({
+    value: createSeed(),
+  }));
+}
+
+export function resetDiffStore(): DiffPayloadDto {
+  const store = getDiffStore();
+  store.value = createSeed();
+  return store.value;
+}

--- a/src/diff/dto/diff.dto.ts
+++ b/src/diff/dto/diff.dto.ts
@@ -1,0 +1,6 @@
+export class DiffPayloadDto {
+  original!: string;
+  modified!: string;
+  language!: string;
+  updatedAt!: string; // ISO-8601
+}

--- a/src/gallery/dto/gallery.dto.ts
+++ b/src/gallery/dto/gallery.dto.ts
@@ -1,0 +1,61 @@
+export class CategoryDto {
+  id!: string;
+  label!: string;
+  activeByDefault!: boolean;
+}
+
+export class GalleryMetaDto {
+  title!: string;
+  version!: string;
+  updatedAt!: string; // ISO-8601
+}
+
+export class ButtonSectionBaseDto {
+  description!: string;
+  variants!: string[];
+}
+
+export class ButtonSectionDto extends ButtonSectionBaseDto {
+  usageTemplate!: string;
+}
+
+export class BadgeExampleDto {
+  label!: string;
+  tone!: string;
+  icon!: string;
+}
+
+export class BadgeSectionDto {
+  description!: string;
+  examples!: BadgeExampleDto[];
+  usageSnippet!: string;
+}
+
+export class InfoCardExampleDto {
+  title!: string;
+  value!: string;
+  hint!: string;
+  tone!: string;
+}
+
+export class InfoCardSectionDto {
+  description!: string;
+  examples!: InfoCardExampleDto[];
+  usageSnippet!: string;
+}
+
+export class GalleryStoreDto {
+  meta!: GalleryMetaDto;
+  categories!: CategoryDto[];
+  button!: ButtonSectionBaseDto;
+  badge!: BadgeSectionDto;
+  infoCard!: InfoCardSectionDto;
+}
+
+export class GalleryPayloadDto {
+  meta!: GalleryMetaDto;
+  categories!: CategoryDto[];
+  button!: ButtonSectionDto;
+  badge!: BadgeSectionDto;
+  infoCard!: InfoCardSectionDto;
+}

--- a/src/gallery/gallery.controller.ts
+++ b/src/gallery/gallery.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  InternalServerErrorException,
+  Options,
+  Patch,
+  Res,
+} from "@nestjs/common";
+import type { Response } from "express";
+import { GalleryPayloadDto, GalleryStoreDto } from "./dto/gallery.dto";
+import { GalleryService } from "./gallery.service";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "http://localhost:3000",
+  "Access-Control-Allow-Methods": "GET,PATCH,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+@Controller("gallery")
+export class GalleryController {
+  constructor(private readonly service: GalleryService) {}
+
+  @Options()
+  @HttpCode(204)
+  options(@Res() res: Response) {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+    return res.send();
+  }
+
+  @Get()
+  get(@Res({ passthrough: true }) res: Response): GalleryPayloadDto {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+      return this.service.getPayload();
+    } catch {
+      throw new InternalServerErrorException("Failed to fetch gallery");
+    }
+  }
+
+  @Patch()
+  patch(
+    @Body() body: unknown,
+    @Res({ passthrough: true }) res: Response
+  ): GalleryStoreDto {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      // Spec: version is applied only if it's a string.
+      const input =
+        body && typeof body === "object" ? (body as { version?: unknown }) : {};
+
+      return this.service.patchVersion(input);
+    } catch {
+      throw new InternalServerErrorException("Failed to update gallery");
+    }
+  }
+}

--- a/src/gallery/gallery.module.ts
+++ b/src/gallery/gallery.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { GalleryController } from "./gallery.controller";
+import { GalleryService } from "./gallery.service";
+
+@Module({
+  controllers: [GalleryController],
+  providers: [GalleryService],
+})
+export class GalleryModule {}

--- a/src/gallery/gallery.seed.ts
+++ b/src/gallery/gallery.seed.ts
@@ -1,0 +1,67 @@
+import { GalleryStoreDto } from "./dto/gallery.dto";
+
+export function seedGalleryStore(): GalleryStoreDto {
+  return {
+    meta: {
+      title: "UI Component Gallery",
+      version: "v0.1.0",
+      updatedAt: new Date().toISOString(),
+    },
+    categories: [
+      { id: "all", label: "All", activeByDefault: true },
+      { id: "buttons", label: "Buttons", activeByDefault: false },
+      { id: "badges", label: "Badges", activeByDefault: false },
+      { id: "cards", label: "Cards", activeByDefault: false },
+    ],
+    button: {
+      description:
+        "액션을 트리거하는 기본 버튼 컴포넌트입니다. 상태와 variant에 따라 스타일이 달라집니다.",
+      variants: ["primary", "secondary", "ghost"],
+    },
+    badge: {
+      description:
+        "상태나 타입을 간단히 표시하는 배지 컴포넌트입니다. 로그 레벨, 태그, 진행 상태 등에 활용합니다.",
+      examples: [
+        { label: "ACTIVE", tone: "info", icon: "check" },
+        { label: "WARNING", tone: "warning", icon: "dot" },
+        { label: "ERROR", tone: "error", icon: "square" },
+        { label: "DRAFT", tone: "draft", icon: "square" },
+      ],
+      usageSnippet:
+        '<Badge variant="info">ACTIVE</Badge>\n' +
+        '<Badge variant="warning">WARNING</Badge>\n' +
+        '<Badge variant="error">ERROR</Badge>',
+    },
+    infoCard: {
+      description:
+        "통계, 상태, 설명 등을 간단히 보여주는 카드 컴포넌트입니다. 대시보드 위젯, 설정 안내 등에 활용할 수 있습니다.",
+      examples: [
+        {
+          title: "Requests / min",
+          value: "1,248",
+          hint: "+12.4% vs last hour",
+          tone: "info",
+        },
+        {
+          title: "Error Rate",
+          value: "0.37%",
+          hint: "Within SLO (1%)",
+          tone: "success",
+        },
+        {
+          title: "Queue Length",
+          value: "182",
+          hint: "Check worker scale",
+          tone: "warning",
+        },
+      ],
+      usageSnippet:
+        "<InfoCard\n" +
+        '  title="Requests / min"\n' +
+        '  value="1,248"\n' +
+        '  hint="+12.4% vs last hour"\n' +
+        '  tone="info"\n' +
+        "/>",
+    },
+  };
+}

--- a/src/gallery/gallery.service.ts
+++ b/src/gallery/gallery.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from "@nestjs/common";
+import { GalleryStoreDto, GalleryPayloadDto } from "./dto/gallery.dto";
+import { getGalleryStore } from "./gallery.store";
+
+@Injectable()
+export class GalleryService {
+  getStore(): GalleryStoreDto {
+    const store = getGalleryStore();
+    return structuredClone(store.value);
+  }
+
+  getPayload(): GalleryPayloadDto {
+    const store = getGalleryStore();
+    const base = store.value;
+
+    const usageTemplateFn = (variant: string) =>
+      `<Button variant="${variant}">\n  Click Me\n</Button>`;
+
+    return {
+      meta: base.meta,
+      categories: base.categories,
+      button: {
+        ...base.button,
+        usageTemplate: usageTemplateFn.toString(),
+      },
+      badge: base.badge,
+      infoCard: base.infoCard,
+    };
+  }
+
+  patchVersion(input: { version?: unknown }): GalleryStoreDto {
+    const store = getGalleryStore();
+    const cur = store.value;
+
+    const next: GalleryStoreDto = {
+      ...cur,
+      meta: {
+        ...cur.meta,
+        version:
+          typeof input.version === "string" ? input.version : cur.meta.version,
+        updatedAt: new Date().toISOString(),
+      },
+    };
+
+    store.value = next;
+    return structuredClone(store.value);
+  }
+}

--- a/src/gallery/gallery.store.ts
+++ b/src/gallery/gallery.store.ts
@@ -1,0 +1,11 @@
+import { getGlobalSingleton } from "src/common/global-singleton";
+import { GalleryStoreDto } from "./dto/gallery.dto";
+import { seedGalleryStore } from "./gallery.seed";
+
+type GalleryStore = { value: GalleryStoreDto };
+
+export function getGalleryStore(): GalleryStore {
+  return getGlobalSingleton<GalleryStore>("__mockGallery", () => ({
+    value: seedGalleryStore(),
+  }));
+}

--- a/src/health/dto/health.dto.ts
+++ b/src/health/dto/health.dto.ts
@@ -1,0 +1,9 @@
+export type ServiceStatus = "UP" | "DEGRADED" | "DOWN";
+
+export class ServiceHealthDto {
+  name!: string;
+  status!: ServiceStatus;
+  latencyMs!: number;
+  errorRate!: number; // 0..5, 2 decimals
+  updatedAt!: string; // ISO-8601
+}

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,92 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  InternalServerErrorException,
+  Options,
+  Post,
+  Res,
+} from "@nestjs/common";
+import type { Response } from "express";
+import { HealthService } from "./health.service";
+import { ServiceHealthDto } from "./dto/health.dto";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "http://localhost:3000",
+  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+type HealthListResponse = {
+  success: true;
+  data: ServiceHealthDto[];
+  count: number;
+};
+type HealthUpsertResponse = { success: true; data: ServiceHealthDto };
+type HealthResetResponse = { success: true; message: string };
+
+@Controller("health")
+export class HealthController {
+  constructor(private readonly service: HealthService) {}
+
+  @Options()
+  @HttpCode(204)
+  options(@Res() res: Response) {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+    return res.send();
+  }
+
+  @Get()
+  get(@Res({ passthrough: true }) res: Response): HealthListResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const data = this.service.list();
+      return { success: true, data, count: data.length };
+    } catch {
+      throw new InternalServerErrorException("Failed to fetch health");
+    }
+  }
+
+  @Post()
+  post(
+    @Body() body: unknown,
+    @Res({ passthrough: true }) res: Response
+  ): HealthUpsertResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const input = body && typeof body === "object" ? (body as any) : {};
+      const name = typeof input.name === "string" ? input.name.trim() : "";
+
+      if (!name) {
+        throw new BadRequestException("name is required");
+      }
+
+      const { item, created } = this.service.upsert(input);
+
+      res.status(created ? 201 : 200);
+
+      return { success: true, data: item };
+    } catch (e) {
+      if (e instanceof BadRequestException) throw e;
+      throw new InternalServerErrorException("Failed to update health");
+    }
+  }
+
+  @Delete()
+  delete(@Res({ passthrough: true }) res: Response): HealthResetResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const { resetCount } = this.service.reset();
+      return { success: true, message: `Reset ${resetCount} services` };
+    } catch {
+      throw new InternalServerErrorException("Failed to reset health");
+    }
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { HealthController } from "./health.controller";
+import { HealthService } from "./health.service";
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}

--- a/src/health/health.seed.ts
+++ b/src/health/health.seed.ts
@@ -1,0 +1,50 @@
+import { ServiceHealthDto } from "./dto/health.dto";
+
+export function seedHealth(): ServiceHealthDto[] {
+  const now = new Date().toISOString();
+
+  return [
+    {
+      name: "api",
+      status: "UP",
+      latencyMs: 54,
+      errorRate: 0.12,
+      updatedAt: now,
+    },
+    {
+      name: "auth",
+      status: "UP",
+      latencyMs: 41,
+      errorRate: 0.08,
+      updatedAt: now,
+    },
+    {
+      name: "worker",
+      status: "UP",
+      latencyMs: 88,
+      errorRate: 0.22,
+      updatedAt: now,
+    },
+    {
+      name: "db",
+      status: "UP",
+      latencyMs: 32,
+      errorRate: 0.03,
+      updatedAt: now,
+    },
+    {
+      name: "cache",
+      status: "UP",
+      latencyMs: 12,
+      errorRate: 0.01,
+      updatedAt: now,
+    },
+    {
+      name: "gateway",
+      status: "UP",
+      latencyMs: 63,
+      errorRate: 0.15,
+      updatedAt: now,
+    },
+  ];
+}

--- a/src/health/health.service.ts
+++ b/src/health/health.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, OnModuleInit } from "@nestjs/common";
+import { getHealthStore, getHealthTicker } from "./health.store";
+import { seedHealth } from "./health.seed";
+import { ServiceStatus, ServiceHealthDto } from "./dto/health.dto";
+
+type UpsertInput = {
+  name?: unknown;
+  status?: unknown;
+  latencyMs?: unknown;
+  errorRate?: unknown;
+};
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function round2(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+function isStatus(x: unknown): x is ServiceStatus {
+  return x === "UP" || x === "DEGRADED" || x === "DOWN";
+}
+
+function computeStatus(latencyMs: number, errorRate: number): ServiceStatus {
+  if (Math.random() < 0.01) return "DOWN";
+
+  if (errorRate > 2 || latencyMs > 200) return "DEGRADED";
+  return "UP";
+}
+
+function tickOne(s: ServiceHealthDto): ServiceHealthDto {
+  const nextLatency = Math.max(
+    1,
+    Math.round(s.latencyMs + (Math.random() * 30 - 15))
+  );
+  const nextError = round2(
+    clamp(s.errorRate + (Math.random() * 0.4 - 0.2), 0, 5)
+  );
+  const nextStatus = computeStatus(nextLatency, nextError);
+
+  return {
+    ...s,
+    latencyMs: nextLatency,
+    errorRate: nextError,
+    status: nextStatus,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+@Injectable()
+export class HealthService implements OnModuleInit {
+  onModuleInit() {
+    this.ensureTicker();
+  }
+
+  ensureTicker() {
+    const ticker = getHealthTicker();
+    if (ticker.started) return;
+
+    ticker.started = true;
+
+    ticker.timer = setInterval(() => {
+      const store = getHealthStore();
+      store.services = store.services.map(tickOne);
+    }, 4000);
+  }
+
+  list(): ServiceHealthDto[] {
+    const store = getHealthStore();
+    return structuredClone(store.services);
+  }
+
+  reset(): { resetCount: number } {
+    const store = getHealthStore();
+    const resetCount = store.services.length;
+    store.services = seedHealth();
+    return { resetCount };
+  }
+
+  upsert(input: UpsertInput): { item: ServiceHealthDto; created: boolean } {
+    const store = getHealthStore();
+
+    const name = typeof input.name === "string" ? input.name.trim() : "";
+    if (!name) {
+      const now = new Date().toISOString();
+      return {
+        created: false,
+        item: {
+          name: "",
+          status: "UP",
+          latencyMs: 0,
+          errorRate: 0,
+          updatedAt: now,
+        },
+      };
+    }
+
+    const idx = store.services.findIndex((s) => s.name === name);
+    const exists = idx >= 0;
+
+    const cur = exists
+      ? store.services[idx]
+      : ({
+          name,
+          status: "UP",
+          latencyMs: 0,
+          errorRate: 0,
+          updatedAt: new Date().toISOString(),
+        } satisfies ServiceHealthDto);
+
+    const next: ServiceHealthDto = {
+      name,
+      status: isStatus(input.status) ? input.status : cur.status,
+      latencyMs:
+        typeof input.latencyMs === "number" ? input.latencyMs : cur.latencyMs,
+      errorRate:
+        typeof input.errorRate === "number" ? input.errorRate : cur.errorRate,
+      updatedAt: new Date().toISOString(),
+    };
+
+    next.latencyMs = Math.max(1, Math.round(next.latencyMs));
+    next.errorRate = round2(clamp(next.errorRate, 0, 5));
+
+    if (!isStatus(input.status)) {
+      next.status = computeStatus(next.latencyMs, next.errorRate);
+    }
+
+    if (exists) {
+      store.services[idx] = next;
+      return { item: structuredClone(next), created: false };
+    }
+
+    store.services.push(next);
+    return { item: structuredClone(next), created: true };
+  }
+}

--- a/src/health/health.store.ts
+++ b/src/health/health.store.ts
@@ -1,0 +1,24 @@
+import { getGlobalSingleton } from "src/common/global-singleton";
+import { ServiceHealthDto } from "./dto/health.dto";
+import { seedHealth } from "./health.seed";
+
+type HealthStore = {
+  services: ServiceHealthDto[];
+};
+
+type HealthTicker = {
+  started: boolean;
+  timer?: NodeJS.Timeout;
+};
+
+export function getHealthStore(): HealthStore {
+  return getGlobalSingleton<HealthStore>("__mockHealth", () => ({
+    services: seedHealth(),
+  }));
+}
+
+export function getHealthTicker(): HealthTicker {
+  return getGlobalSingleton<HealthTicker>("__mockHealthTicker", () => ({
+    started: false,
+  }));
+}

--- a/src/logs/dto/logs.dto.ts
+++ b/src/logs/dto/logs.dto.ts
@@ -1,0 +1,7 @@
+export class LogEntryDto {
+  id!: number; // Date.now()
+  timestamp!: string; // toLocaleTimeString("ko-KR")
+  level!: string;
+  message!: string; // default "No message provided"
+  createdAt!: string; // ISO-8601
+}

--- a/src/logs/logs.controller.ts
+++ b/src/logs/logs.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  InternalServerErrorException,
+  Post,
+  Query,
+  Req,
+  Res,
+} from "@nestjs/common";
+import type { Request, Response } from "express";
+import { LogsService } from "./logs.service";
+import { LogEntryDto } from "./dto/logs.dto";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "http://localhost:3000",
+  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+type LogsListResponse = { success: true; data: LogEntryDto[]; count: number };
+type LogsCreateResponse = { success: true; data: LogEntryDto };
+type LogsClearResponse = { success: true; message: string };
+
+@Controller("logs")
+export class LogsController {
+  constructor(private readonly service: LogsService) {}
+
+  @Get()
+  get(
+    @Query("level") level: string | undefined,
+    @Res({ passthrough: true }) res: Response
+  ): LogsListResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const data = this.service.list(level);
+      return { success: true, data, count: data.length };
+    } catch {
+      throw new InternalServerErrorException("Failed to fetch logs");
+    }
+  }
+
+  @Post()
+  post(
+    @Req() req: Request & { rawBody?: string },
+    @Res({ passthrough: true }) res: Response
+  ): LogsCreateResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const raw = typeof req.rawBody === "string" ? req.rawBody : "";
+      let parsed: any = undefined;
+
+      if (raw && raw.trim().length > 0) {
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          parsed = undefined;
+        }
+      }
+
+      const entry = this.service.createFromParsed(parsed);
+      res.status(201);
+      return { success: true, data: entry };
+    } catch {
+      throw new InternalServerErrorException("Failed to create log");
+    }
+  }
+
+  @Delete()
+  delete(@Res({ passthrough: true }) res: Response): LogsClearResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const { cleared } = this.service.clear();
+      return { success: true, message: `Cleared ${cleared} logs` };
+    } catch {
+      throw new InternalServerErrorException("Failed to clear logs");
+    }
+  }
+}

--- a/src/logs/logs.module.ts
+++ b/src/logs/logs.module.ts
@@ -1,0 +1,16 @@
+import { MiddlewareConsumer, Module, RequestMethod } from "@nestjs/common";
+import { LogsController } from "./logs.controller";
+import { LogsService } from "./logs.service";
+import { logsRawBodyMiddleware } from "./logs.raw-body.middleware";
+
+@Module({
+  controllers: [LogsController],
+  providers: [LogsService],
+})
+export class LogsModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(logsRawBodyMiddleware())
+      .forRoutes({ path: "logs", method: RequestMethod.POST });
+  }
+}

--- a/src/logs/logs.raw-body.middleware.ts
+++ b/src/logs/logs.raw-body.middleware.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, NextFunction } from "express";
+import { text } from "express";
+
+export function logsRawBodyMiddleware() {
+  const parser = text({ type: "*/*" });
+
+  return (
+    req: Request & { rawBody?: string },
+    res: Response,
+    next: NextFunction
+  ) => {
+    parser(req, res, (err) => {
+      if (err) return next(err);
+
+      if (typeof (req as any).body === "string")
+        req.rawBody = (req as any).body;
+      else req.rawBody = "";
+
+      next();
+    });
+  };
+}

--- a/src/logs/logs.service.ts
+++ b/src/logs/logs.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from "@nestjs/common";
+import { logs } from "./logs.store";
+import { LogEntryDto } from "./dto/logs.dto";
+
+function nowKoTimeString(): string {
+  return new Date().toLocaleTimeString("ko-KR");
+}
+
+@Injectable()
+export class LogsService {
+  list(level?: string): LogEntryDto[] {
+    const data = level ? logs.filter((l) => l.level === level) : logs;
+    return structuredClone(data);
+  }
+
+  createFromParsed(parsed: any): LogEntryDto {
+    const level =
+      parsed && typeof parsed.level === "string" ? parsed.level : "INFO";
+    const message =
+      parsed && typeof parsed.message === "string"
+        ? parsed.message
+        : "No message provided";
+
+    const entry: LogEntryDto = {
+      id: Date.now(),
+      timestamp: nowKoTimeString(),
+      level,
+      message,
+      createdAt: new Date().toISOString(),
+    };
+
+    logs.push(entry);
+    return structuredClone(entry);
+  }
+
+  clear(): { cleared: number } {
+    const cleared = logs.length;
+    logs.length = 0;
+    return { cleared };
+  }
+}

--- a/src/logs/logs.store.ts
+++ b/src/logs/logs.store.ts
@@ -1,0 +1,3 @@
+import { LogEntryDto } from "./dto/logs.dto";
+
+export const logs: LogEntryDto[] = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { ValidationPipe } from "@nestjs/common";
+import {
+  ApiResponseInterceptor,
+  ApiExceptionFilter,
+} from "./common/http/api-response";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -23,6 +27,9 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     })
   );
+
+  app.useGlobalInterceptors(new ApiResponseInterceptor());
+  app.useGlobalFilters(new ApiExceptionFilter());
 
   // Next랑 3000 포트 겹치기 때문에 4000 포트로 변경
   await app.listen(process.env.PORT ?? 4000);

--- a/src/metrics/dto/metrics.dto.ts
+++ b/src/metrics/dto/metrics.dto.ts
@@ -1,0 +1,6 @@
+export type MetricType = "requests" | "errors" | "db";
+
+export class MetricDataPointDto {
+  timestamp!: number; // Date.now()
+  value!: number;
+}

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -1,0 +1,96 @@
+// metrics.controller.ts
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  InternalServerErrorException,
+  Options,
+  Post,
+  Query,
+  Res,
+} from "@nestjs/common";
+import type { Response } from "express";
+import { MetricsService } from "./metrics.service";
+import { MetricDataPointDto, MetricType } from "./dto/metrics.dto";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "http://localhost:3000",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+type MetricsGetResponse = {
+  success: true;
+  type: MetricType;
+  data: MetricDataPointDto[];
+  count: number;
+};
+
+type MetricsPostResponse = {
+  success: true;
+  type: MetricType;
+  data: MetricDataPointDto;
+};
+
+@Controller("metrics")
+export class MetricsController {
+  constructor(private readonly service: MetricsService) {}
+
+  @Options()
+  @HttpCode(204)
+  options(@Res() res: Response) {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+    return res.send();
+  }
+
+  @Get()
+  get(
+    @Query("type") type: string | undefined,
+    @Res({ passthrough: true }) res: Response
+  ): MetricsGetResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      if (!this.service.isValidType(type)) {
+        throw new BadRequestException(
+          "Invalid metric type. Use: requests, errors, or db"
+        );
+      }
+
+      const data = this.service.list(type);
+      return { success: true, type, data, count: data.length };
+    } catch (e) {
+      if (e instanceof BadRequestException) throw e;
+      throw new InternalServerErrorException("Failed to fetch metrics");
+    }
+  }
+
+  @Post()
+  post(
+    @Body() body: unknown,
+    @Res({ passthrough: true }) res: Response
+  ): MetricsPostResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const input = body && typeof body === "object" ? (body as any) : {};
+      const type = input.type;
+
+      if (!this.service.isValidType(type)) {
+        throw new BadRequestException("Invalid metric type");
+      }
+
+      const value = typeof input.value === "number" ? input.value : undefined;
+      const point = this.service.add(type, value);
+
+      res.status(201);
+      return { success: true, type, data: point };
+    } catch (e) {
+      if (e instanceof BadRequestException) throw e;
+      throw new InternalServerErrorException("Failed to add metric");
+    }
+  }
+}

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { MetricsController } from "./metrics.controller";
+import { MetricsService } from "./metrics.service";
+
+@Module({
+  controllers: [MetricsController],
+  providers: [MetricsService],
+})
+export class MetricsModule {}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, OnModuleInit } from "@nestjs/common";
+import { metricsHistory } from "./metrics.store";
+import { MetricType, MetricDataPointDto } from "./dto/metrics.dto";
+
+const MAX_POINTS = 50;
+
+type MetricsTicker = { timer?: NodeJS.Timeout | null };
+const g = globalThis as unknown as Record<string, any>;
+
+function getTicker(): MetricsTicker {
+  if (!g.__mockMetricsTicker) g.__mockMetricsTicker = { timer: null };
+  return g.__mockMetricsTicker as MetricsTicker;
+}
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function round2(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+function isMetricType(x: unknown): x is MetricType {
+  return x === "requests" || x === "errors" || x === "db";
+}
+
+function trimHistory(type: MetricType) {
+  const arr = metricsHistory[type];
+  while (arr.length > MAX_POINTS) arr.shift();
+}
+
+function generateNextValue(type: MetricType, prev: number): number {
+  if (type === "requests") {
+    const next = prev + (Math.random() * 40 - 20); // ±20
+    return Math.round(clamp(next, 80, 200));
+  }
+  if (type === "errors") {
+    const next = prev + (Math.random() * 1.0 - 0.5); // ±0.5
+    return round2(clamp(next, 0, 3));
+  }
+  // db
+  const next = prev + (Math.random() * 100 - 50); // ±50
+  return Math.round(clamp(next, 250, 650));
+}
+
+function defaultSeedValue(type: MetricType): number {
+  if (type === "requests") return 120;
+  if (type === "errors") return 0.5;
+  return 400;
+}
+
+function addPoint(type: MetricType, value?: number): MetricDataPointDto {
+  const arr = metricsHistory[type];
+  const prev =
+    arr.length > 0 ? arr[arr.length - 1].value : defaultSeedValue(type);
+  const v = typeof value === "number" ? value : generateNextValue(type, prev);
+
+  const point: MetricDataPointDto = { timestamp: Date.now(), value: v };
+  arr.push(point);
+  trimHistory(type);
+  return point;
+}
+
+function seedIfEmpty() {
+  (["requests", "errors", "db"] as MetricType[]).forEach((type) => {
+    if (metricsHistory[type].length > 0) return;
+
+    const now = Date.now();
+    const baseTsStart = now - 30_000 * 20;
+    let prev = defaultSeedValue(type);
+
+    for (let i = 0; i < 20; i++) {
+      prev = generateNextValue(type, prev);
+      metricsHistory[type].push({
+        timestamp: baseTsStart + 30_000 * i,
+        value: prev,
+      });
+    }
+
+    trimHistory(type);
+  });
+}
+
+@Injectable()
+export class MetricsService implements OnModuleInit {
+  onModuleInit() {
+    seedIfEmpty();
+    this.ensureAutoUpdate();
+  }
+
+  private ensureAutoUpdate() {
+    const ticker = getTicker();
+
+    if (ticker.timer) clearInterval(ticker.timer);
+
+    ticker.timer = setInterval(() => {
+      (["requests", "errors", "db"] as MetricType[]).forEach((type) => {
+        addPoint(type);
+      });
+    }, 10_000);
+  }
+
+  list(type: MetricType): MetricDataPointDto[] {
+    return structuredClone(metricsHistory[type]);
+  }
+
+  add(type: MetricType, value?: number): MetricDataPointDto {
+    return structuredClone(addPoint(type, value));
+  }
+
+  isValidType(x: unknown): x is MetricType {
+    return isMetricType(x);
+  }
+}

--- a/src/metrics/metrics.store.ts
+++ b/src/metrics/metrics.store.ts
@@ -1,0 +1,7 @@
+import { MetricType, MetricDataPointDto } from "./dto/metrics.dto";
+
+export const metricsHistory: Record<MetricType, MetricDataPointDto[]> = {
+  requests: [],
+  errors: [],
+  db: [],
+};

--- a/src/topics/dto/topics.dto.ts
+++ b/src/topics/dto/topics.dto.ts
@@ -1,0 +1,10 @@
+export class TopicEntryDto {
+  name!: string;
+  partitions!: number;
+  replicationFactor!: number;
+  messageInPerSec!: number;
+  messageOutPerSec!: number;
+  lag!: number;
+  sizeGB!: number;
+  updatedAt!: string; // ISO-8601
+}

--- a/src/topics/topics.controller.ts
+++ b/src/topics/topics.controller.ts
@@ -1,0 +1,106 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  InternalServerErrorException,
+  NotFoundException,
+  Options,
+  Post,
+  Query,
+  Body,
+  Res,
+} from "@nestjs/common";
+import type { Response } from "express";
+import { TopicsService } from "./topics.service";
+import { TopicEntryDto } from "./dto/topics.dto";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "http://localhost:3000",
+  "Access-Control-Allow-Methods": "GET,POST,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+} as const;
+
+type TopicsListResponse = {
+  success: true;
+  data: TopicEntryDto[];
+  count: number;
+};
+type TopicSingleResponse = { success: true; data: TopicEntryDto };
+type TopicCreateResponse = { success: true; data: TopicEntryDto };
+type TopicsResetResponse = { success: true; message: string };
+
+@Controller("topics")
+export class TopicsController {
+  constructor(private readonly service: TopicsService) {}
+
+  @Options()
+  @HttpCode(204)
+  options(@Res() res: Response) {
+    for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+    return res.send();
+  }
+
+  @Get()
+  get(
+    @Query("name") name: string | undefined,
+    @Res({ passthrough: true }) res: Response
+  ): TopicsListResponse | TopicSingleResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      if (typeof name === "string" && name.trim()) {
+        const found = this.service.findByName(name.trim());
+        if (!found) throw new NotFoundException("Topic not found");
+        return { success: true, data: found };
+      }
+
+      const data = this.service.list();
+      return { success: true, data, count: data.length };
+    } catch (e) {
+      if (e instanceof NotFoundException) throw e;
+      throw new InternalServerErrorException("Failed to fetch topics");
+    }
+  }
+
+  @Post()
+  post(
+    @Body() body: unknown,
+    @Res({ passthrough: true }) res: Response
+  ): TopicCreateResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const input = body && typeof body === "object" ? (body as any) : {};
+      const name = typeof input.name === "string" ? input.name.trim() : "";
+
+      if (!name) throw new BadRequestException("name is required");
+
+      const { created, alreadyExists } = this.service.create(input);
+      if (alreadyExists) throw new ConflictException("Topic already exists");
+
+      res.status(201);
+      return { success: true, data: created };
+    } catch (e) {
+      if (e instanceof BadRequestException || e instanceof ConflictException) {
+        throw e;
+      }
+      throw new InternalServerErrorException("Failed to create topic");
+    }
+  }
+
+  @Delete()
+  delete(@Res({ passthrough: true }) res: Response): TopicsResetResponse {
+    try {
+      for (const [k, v] of Object.entries(corsHeaders)) res.setHeader(k, v);
+
+      const { resetCount } = this.service.reset();
+      return { success: true, message: `Reset ${resetCount} topics` };
+    } catch {
+      throw new InternalServerErrorException("Failed to reset topics");
+    }
+  }
+}

--- a/src/topics/topics.module.ts
+++ b/src/topics/topics.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { TopicsController } from "./topics.controller";
+import { TopicsService } from "./topics.service";
+
+@Module({
+  controllers: [TopicsController],
+  providers: [TopicsService],
+})
+export class TopicsModule {}

--- a/src/topics/topics.seed.ts
+++ b/src/topics/topics.seed.ts
@@ -1,0 +1,78 @@
+import { TopicEntryDto } from "./dto/topics.dto";
+
+export function seedTopics(): TopicEntryDto[] {
+  const now = new Date().toISOString();
+
+  return [
+    {
+      name: "orders",
+      partitions: 10,
+      replicationFactor: 2,
+      messageInPerSec: 180,
+      messageOutPerSec: 165,
+      lag: 42,
+      sizeGB: 18,
+      updatedAt: now,
+    },
+    {
+      name: "payments",
+      partitions: 8,
+      replicationFactor: 2,
+      messageInPerSec: 120,
+      messageOutPerSec: 118,
+      lag: 12,
+      sizeGB: 9,
+      updatedAt: now,
+    },
+    {
+      name: "users",
+      partitions: 6,
+      replicationFactor: 2,
+      messageInPerSec: 60,
+      messageOutPerSec: 58,
+      lag: 4,
+      sizeGB: 6,
+      updatedAt: now,
+    },
+    {
+      name: "logs",
+      partitions: 6,
+      replicationFactor: 2,
+      messageInPerSec: 20,
+      messageOutPerSec: 20,
+      lag: 0,
+      sizeGB: 3,
+      updatedAt: now,
+    },
+    {
+      name: "metrics",
+      partitions: 6,
+      replicationFactor: 2,
+      messageInPerSec: 15,
+      messageOutPerSec: 14,
+      lag: 1,
+      sizeGB: 2,
+      updatedAt: now,
+    },
+    {
+      name: "notifications",
+      partitions: 12,
+      replicationFactor: 3,
+      messageInPerSec: 75,
+      messageOutPerSec: 70,
+      lag: 9,
+      sizeGB: 7,
+      updatedAt: now,
+    },
+    {
+      name: "analytics",
+      partitions: 18,
+      replicationFactor: 2,
+      messageInPerSec: 95,
+      messageOutPerSec: 90,
+      lag: 18,
+      sizeGB: 22,
+      updatedAt: now,
+    },
+  ];
+}

--- a/src/topics/topics.service.ts
+++ b/src/topics/topics.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, OnModuleInit } from "@nestjs/common";
+import { getTopicsStore, getTopicsTicker } from "./topics.store";
+import { seedTopics } from "./topics.seed";
+import { TopicEntryDto } from "./dto/topics.dto";
+
+type CreateTopicInput = {
+  name?: unknown;
+  partitions?: unknown;
+  replicationFactor?: unknown;
+  messageInPerSec?: unknown;
+  messageOutPerSec?: unknown;
+  lag?: unknown;
+  sizeGB?: unknown;
+};
+
+function clampMin(n: number, min: number) {
+  return Math.max(min, n);
+}
+
+function wobbleInt(n: number, delta: number, min: number) {
+  const next = Math.round(n + (Math.random() * (delta * 2) - delta));
+  return clampMin(next, min);
+}
+
+@Injectable()
+export class TopicsService implements OnModuleInit {
+  onModuleInit() {
+    this.ensureTicker();
+  }
+
+  private ensureTicker() {
+    const ticker = getTopicsTicker();
+    if (ticker.started) return;
+
+    ticker.started = true;
+    ticker.timer = setInterval(() => {
+      const store = getTopicsStore();
+      const now = new Date().toISOString();
+
+      store.topics = store.topics.map((t) => ({
+        ...t,
+        messageInPerSec: wobbleInt(t.messageInPerSec, 25, 0),
+        messageOutPerSec: wobbleInt(t.messageOutPerSec, 25, 0),
+        lag: wobbleInt(t.lag, 60, 0),
+        sizeGB: wobbleInt(t.sizeGB, 1, 1),
+        updatedAt: now,
+      }));
+    }, 5000);
+  }
+
+  list(): TopicEntryDto[] {
+    const store = getTopicsStore();
+    return structuredClone(store.topics);
+  }
+
+  findByName(name: string): TopicEntryDto | undefined {
+    const store = getTopicsStore();
+    const found = store.topics.find((t) => t.name === name);
+    return found ? structuredClone(found) : undefined;
+  }
+
+  create(input: CreateTopicInput): {
+    created: TopicEntryDto;
+    alreadyExists: boolean;
+  } {
+    const store = getTopicsStore();
+
+    const name = typeof input.name === "string" ? input.name.trim() : "";
+    if (!name) {
+      return {
+        alreadyExists: false,
+        created: {
+          name: "",
+          partitions: 6,
+          replicationFactor: 2,
+          messageInPerSec: 0,
+          messageOutPerSec: 0,
+          lag: 0,
+          sizeGB: 1,
+          updatedAt: new Date().toISOString(),
+        },
+      };
+    }
+
+    if (store.topics.some((t) => t.name === name)) {
+      return {
+        alreadyExists: true,
+        created: structuredClone(store.topics.find((t) => t.name === name)!),
+      };
+    }
+
+    const topic: TopicEntryDto = {
+      name,
+      partitions:
+        typeof input.partitions === "number" ? Math.round(input.partitions) : 6,
+      replicationFactor:
+        typeof input.replicationFactor === "number"
+          ? Math.round(input.replicationFactor)
+          : 2,
+      messageInPerSec:
+        typeof input.messageInPerSec === "number"
+          ? Math.round(input.messageInPerSec)
+          : 0,
+      messageOutPerSec:
+        typeof input.messageOutPerSec === "number"
+          ? Math.round(input.messageOutPerSec)
+          : 0,
+      lag: typeof input.lag === "number" ? Math.round(input.lag) : 0,
+      sizeGB: typeof input.sizeGB === "number" ? Math.round(input.sizeGB) : 1,
+      updatedAt: new Date().toISOString(),
+    };
+
+    topic.lag = clampMin(topic.lag, 0);
+    topic.sizeGB = clampMin(topic.sizeGB, 1);
+    topic.messageInPerSec = clampMin(topic.messageInPerSec, 0);
+    topic.messageOutPerSec = clampMin(topic.messageOutPerSec, 0);
+
+    store.topics.push(topic);
+    return { alreadyExists: false, created: structuredClone(topic) };
+  }
+
+  reset(): { resetCount: number } {
+    const store = getTopicsStore();
+    const resetCount = store.topics.length;
+    store.topics = seedTopics();
+    return { resetCount };
+  }
+}

--- a/src/topics/topics.store.ts
+++ b/src/topics/topics.store.ts
@@ -1,0 +1,18 @@
+import { getGlobalSingleton } from "src/common/global-singleton";
+import { TopicEntryDto } from "./dto/topics.dto";
+import { seedTopics } from "./topics.seed";
+
+type TopicsStore = { topics: TopicEntryDto[] };
+type TopicsTicker = { started: boolean; timer?: NodeJS.Timeout };
+
+export function getTopicsStore(): TopicsStore {
+  return getGlobalSingleton<TopicsStore>("__mockTopics", () => ({
+    topics: seedTopics(),
+  }));
+}
+
+export function getTopicsTicker(): TopicsTicker {
+  return getGlobalSingleton<TopicsTicker>("__mockTopicsTicker", () => ({
+    started: false,
+  }));
+}


### PR DESCRIPTION
## Summary 🧩

* Next.js Route Handler 기반 Mock API 명세를 NestJS로 이식
* 공통 응답 포맷 통일: `success/data`, `success/error`
* 명세상 top-level 필드(`count/type/message`) 필요한 API는 `{ success:true, ... }` 형태로 직접 반환(중복 래핑 방지)
* 저장소 정책: `globalThis singleton` vs `process-local memory` 명세대로 분리

---

## What’s included ✅

### Common

* Global Interceptor: `ApiResponseInterceptor`
* Global Filter: `ApiExceptionFilter`
* `getGlobalSingleton` 유틸 (dev/HMR store/ticker 유지)

### Endpoints

* **Dashboard**

  * `GET /api/dashboard`
* **Diff** (globalThis)

  * `GET /api/diff`
  * `POST /api/diff` (partial update: 문자열만 반영, `updatedAt` 갱신)
  * `DELETE /api/diff` (seed reset)
* **Component Gallery** (globalThis)

  * `GET /api/nent-gallery` (`usageTemplate` 런타임 주입 → JSON 대응 위해 문자열 형태)
  * `PATCH /api/gallery` (meta.version 업데이트, store 형태 반환/usageTemplate 제외)
* **Health** (globalThis + tick)

  * `GET /api/health` (+ `count`)
  * `POST /api/health` (upsert: create=201 / update=200, name required=400)
  * `DELETE /api/health` (`message`)
  * `setInterval(4000ms)` latency/errorRate/status 갱신
* **Logs** (process-local)

  * `GET /api/logs?level=` (+ `count`, 완전 일치 필터)
  * `POST /api/logs` (raw text → JSON.parse 시도, 실패/빈 body도 기본값 생성, 201)
  * `DELETE /api/logs` (`message`)
* **Metrics** (process-local + tick)

  * `GET /api/metrics?type=` (type 필수/검증, +`count`)
  * `POST /api/metrics` (value optional, 201, 최대 50 유지)
  * seed(30초 간격 “최근 구간”), `setInterval(10000ms)` 자동 포인트 추가
* **Topics** (globalThis + wobble)

  * `GET /api/topics` (+ `count`)
  * `GET /api/topics?name=` (없으면 404 `"Topic not found"`)
  * `POST /api/topics` (name required=400, duplicate=409, 201)
  * `DELETE /api/topics` (`message`)
  * `setInterval(5000ms)` message/lag/size wobble

---

## Storage / Timer Policy 🕒

* **globalThis singleton 유지**

  * `diff`, `component-gallery`, `health`, `topics`
* **process-local memory**

  * `logs`, `metrics`
* **interval ticker guard 적용**

  * `health`, `topics`, `metrics` (dev/HMR 중복 실행 방지)

---

## How to test 🧪

* `GET /api/health` → `count` 확인 + 4초 후 값 변동 확인
* `POST /api/health` → create 201 / update 200 확인
* `POST /api/logs` → 빈 body/깨진 JSON도 201로 생성되는지 확인
* `GET /api/metrics?type=requests` → 정상 / `type` 누락 시 400 메시지 확인
* `GET /api/topics?name=unknown` → 404 `"Topic not found"` 확인
* `PATCH /api/component-gallery` → `usageTemplate` 미포함 store 응답 확인

---

## Notes ⚠️

* `logs/metrics`는 프로세스 로컬이라 서버 재시작/리로드 시 초기화 가능(명세 동일)
* `component-gallery.usageTemplate`는 함수 직렬화 불가 → GET 응답에서 문자열 형태로 제공

